### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "videos"
   ],
   "description": "Import videos from cloud (Google Cloud Storage, Amazon S3, Microsoft Azure, ...)",
-  "docker_image": "supervisely/import-export:6.73.291",
+  "docker_image": "supervisely/import-export:6.73.564",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "videos"
   ],
   "description": "Import videos from cloud (Google Cloud Storage, Amazon S3, Microsoft Azure, ...)",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/import-export:6.73.564",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "videos"
   ],
   "description": "Import videos from cloud (Google Cloud Storage, Amazon S3, Microsoft Azure, ...)",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -13,6 +13,6 @@
   "icon": "https://i.imgur.com/dAeEkoO.png",
   "icon_background": "#FFFFFF",
   "disable_stop": true,
-  "instance_version": "6.12.23",
+  "instance_version": "6.15.60",
   "poster": "https://user-images.githubusercontent.com/106374579/186632514-667f50f1-c261-4ad2-a24b-c8092419eb31.png"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.291
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
